### PR TITLE
Deprecate old style map rotation

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -188,50 +188,14 @@ name = "Next Map"
 value = "next_map"
 inline = true
 
-
 ####################################
 #                                  #
 #           Map Rotation           #
-#          (colored text)          #
-#         Message Section          #
-#                                  #
-####################################
-# Display the map rotation as a list of triple backtick ` color coded code blocks
-# https://www.technipages.com/discord-code-blocks
-[display.map_rotation.color]
-enabled = false
-# In seconds, there is a lower limit on how fast you can refresh
-# as determined by the delay time between calling your CRCON and then sending the message to Discord
-time_between_refreshes = 60
-display_title = true
-title = "Map Rotation"
-# Valid options are: auto, cyan, green, orange, gray
-current_map_color = "cyan"
-next_map_color = "green"
-other_map_color = "auto"
-
-display_legend = true
-legend_title = """
-
-Legend
-"""
-legend = ["Current Map", "Next Map", "Other Maps"]
-
-# Include the last refresh time in the footer of the message
-display_last_refreshed = true
-last_refresh_text = """
-Last refreshed <t:{0}:R>
-"""
-
-
-####################################
-#                                  #
-#   Map Rotation Message Section   #
 #                                  #
 ####################################
 
 # Display the map rotation as Discord Embed of fields
-[display.map_rotation.embed]
+[display.map_rotation]
 enabled = true
 # In seconds, there is a lower limit on how fast you can refresh
 # as determined by the delay time between calling your CRCON and then sending the message to Discord
@@ -252,7 +216,7 @@ Legend
 ⬛ - Other Maps
 """
 
-[display.map_rotation.embed.footer]
+[display.map_rotation.footer]
 # Display order is {footer_text} {last_refresh_text} {timestamp}
 # spacing, newlines, etc. are up to you
 

--- a/hll_server_status/constants.py
+++ b/hll_server_status/constants.py
@@ -70,14 +70,6 @@ PLAYER_STATS_EMBEDS: Final = (
     EMPTY_EMBED,
 )
 
-COLOR_TO_CODE_BLOCK: Final = {
-    "auto": "",
-    "cyan": "yaml",  # dsconfig
-    "green": "less",  # less
-    "orange": "ebnf",  # fix ldif mathematica
-    "gray": "bf",  # flix
-}
-
 BETWEEN_MATCHES_MAP_NAME: Final = "Untitled"
 MAP_RESTART_SUFFIX: Final = "_RESTART"
 

--- a/hll_server_status/io.py
+++ b/hll_server_status/io.py
@@ -30,8 +30,7 @@ from hll_server_status.types import (
 from hll_server_status.utils import (
     build_gamestate,
     build_header,
-    build_map_rotation_color,
-    build_map_rotation_embed,
+    build_map_rotation,
     build_player_stats_embed,
 )
 
@@ -65,15 +64,10 @@ def get_producer_config_values(config: Config, key: str) -> tuple[bool, int, Cal
             config.display.gamestate.time_between_refreshes,
             build_gamestate,
         ),
-        "map_rotation_color": (
-            config.display.map_rotation.color.enabled,
-            config.display.map_rotation.color.time_between_refreshes,
-            build_map_rotation_color,
-        ),
         "map_rotation": (
-            config.display.map_rotation.embed.enabled,
-            config.display.map_rotation.embed.time_between_refreshes,
-            build_map_rotation_embed,
+            config.display.map_rotation.enabled,
+            config.display.map_rotation.time_between_refreshes,
+            build_map_rotation,
         ),
         "player_stats": (
             config.display.player_stats.enabled,

--- a/hll_server_status/types.py
+++ b/hll_server_status/types.py
@@ -281,29 +281,6 @@ class DisplayGamestateConfig(pydantic.BaseModel):
     embeds: list[GamestateEmbedConfig]
 
 
-class DisplayMapRotationColorConfig(pydantic.BaseModel):
-    enabled: bool
-    # pylance complains about this even though it's valid with pydantic
-    time_between_refreshes: pydantic.conint(ge=1)  # type: ignore
-    display_title: bool
-    title: str
-    current_map_color: str
-    next_map_color: str
-    other_map_color: str
-    display_legend: bool
-    legend_title: str
-    legend: list[str]
-    display_last_refreshed: bool
-    last_refresh_text: str
-
-    @pydantic.field_validator("current_map_color", "next_map_color", "other_map_color")
-    def must_be_valid_current_map_color(cls, v, field):
-        if v not in constants.COLOR_TO_CODE_BLOCK.keys():
-            raise ValueError(f"Invalid [display.map_rotation] {field}={v}")
-
-        return v
-
-
 class DisplayMapRotationEmbedConfig(pydantic.BaseModel):
     enabled: bool
     # pylance complains about this even though it's valid with pydantic
@@ -316,11 +293,6 @@ class DisplayMapRotationEmbedConfig(pydantic.BaseModel):
     display_legend: bool
     legend: str
     footer: DisplayFooterConfig
-
-
-class DisplayConfigMapRotation(pydantic.BaseModel):
-    color: DisplayMapRotationColorConfig
-    embed: DisplayMapRotationEmbedConfig
 
 
 class PlayerStatsEmbedConfig(pydantic.BaseModel):
@@ -351,7 +323,7 @@ class DisplayPlayerStatsConfig(pydantic.BaseModel):
 class DisplayConfig(pydantic.BaseModel):
     header: DisplayHeaderConfig
     gamestate: DisplayGamestateConfig
-    map_rotation: DisplayConfigMapRotation
+    map_rotation: DisplayMapRotationEmbedConfig
     player_stats: DisplayPlayerStatsConfig
 
 


### PR DESCRIPTION
Remove the `color` based map rotation stuff, it sucked and I don't think anyone used it anyway. The embed version is just better.